### PR TITLE
Refactor/simplify orders

### DIFF
--- a/headers/CommandProcessing.h
+++ b/headers/CommandProcessing.h
@@ -8,9 +8,9 @@
 #include <queue>
 
 //  Forward declaration of required classes from other header files. (included in .cpp file)
-class State;                //  GameEngine.cpp
-class TransitionData;       //  GameEngine.cpp
-class GameEngine;           //  GameEngine.cpp
+class State;                //  GameEngine.h
+class TransitionData;       //  GameEngine.h
+class GameEngine;           //  GameEngine.h
 
 
 

--- a/headers/Orders.h
+++ b/headers/Orders.h
@@ -9,9 +9,6 @@
 class Territory;    //  Map.h
 class Player;       //  Player.h
 
-//  Forward declaration of classes
-class OrdersList;
-
 
 
 using namespace std;
@@ -19,6 +16,8 @@ using namespace std;
 
 // Global string array containing all allowed orders
 const string allowedOrders[6] = {"deploy", "advance", "bomb", "blockade", "airlift", "negotiate"};
+
+
 
 /**
  * \class   Order
@@ -32,12 +31,18 @@ public:
      * \param   type Type of the Order object created
      * \param   target Territory targeted by the order
      */
-    Order(OrdersList *ordersList, string type, Territory *target);
+    Order(Player *owner, const string& type, Territory *target);
+
     /**
      * \brief   Constructs an Order object using values from another Order object
      * \param   order Other Order object to copy member variables from
      */
     Order(Order &order);
+
+    /**
+     * \brief   Deallocates dynamically declared memory during runtime
+     */
+    virtual ~Order();
 
     /**
      * \brief   Verifies if the order is valid, has to be implemented in child classes
@@ -63,8 +68,8 @@ public:
     friend ostream &operator<<(ostream &outs, const Order &order);
 
 protected:
-    // OrdersList object that holds order
-    OrdersList *ordersList;
+    //  Pointer to the player that owns the object
+    Player *owner;
     //  Type of order
     string type;
     // Territory targeted by the order
@@ -78,15 +83,11 @@ protected:
 class OrdersList
 {
 public:
-    // List of pointers to Order objects
-    list<Order *> orders;
-    // Owner of orders list
-    Player *owner;
-
     /**
      * \brief   Constructs an OrdersList object with an empty list of orders
      */
     explicit OrdersList(Player *owner);
+
     /**
      * \brief   Constructs an OrdersList object using values from another OrdersList object
      * \param   ordersList Other OrdersList object to copy member variables from
@@ -94,11 +95,39 @@ public:
     OrdersList(OrdersList &ordersList);
 
     /**
+     * \brief   Appends a pointer to the end of the orders list - if it is not null
+     * \param order Pointer to an Order object
+     * \return  Returns true if append was successful, false otherwise
+     */
+    bool addOrder(Order* order);
+
+    /**
+     * \brief   Pops the head pointer in the list
+     * \return  Pointer to an Order object; head of the list
+     */
+    Order* getNextOrder();
+
+    /**
+     * \brief   Gets the owner
+     * \return  Pointer to a player object
+     */
+    const Player* getOwner() const;
+
+    /**
+     * \brief   Takes in a function, then applies that function to each order in the list
+     * \param func  Function to apply to each Order element in the list
+     * \remarks Solution to external iteration. Now iteration can occur internally through passing of a function.
+     *          Upholds encapsulation.
+     */
+    void apply(void (*func)(Order*));
+
+    /**
      * \brief   Removes the specified order from the list
      * \param   order Order to be removed from the list
      * \return  True if order removal is successful, false otherwise
      */
     void remove(Order *order);
+
     /**
      * \brief   Moves specified order to specified index in the list
      * \param   order Order to be moved
@@ -106,6 +135,14 @@ public:
      * \return  True if order moving is successful, false otherwise
      */
     bool move(Order *order, int index);
+
+    /**
+     * \brief   Directly accesses the internal orders list
+     * \param index Index of internal list
+     * \return  Returns a Order pointer using the passed index. Returns nullptr if invalid index.
+     */
+    Order* operator[](std::size_t index);
+
     /**
      * \brief   Assigns new values to member variables of the OrdersList object
      * \param   ordersList OrdersList object from which new values are to be taken
@@ -116,6 +153,12 @@ public:
      * \brief   Stream insertion override, prints all orders contained in the list
      */
     friend ostream &operator<<(ostream &outs, const OrdersList &ordersList);
+
+private:
+    // List of pointers to Order objects
+    list<Order *> orders;
+    // Owner of orders list
+    Player *owner;
 };
 
 /**
@@ -132,12 +175,18 @@ public:
      * \param   target Territory to which troops are to be deployed
      * \param   armyUnits Number of army units to be deployed
      */
-    DeployOrder(OrdersList *ordersList, Territory *target, int armyUnits);
+    DeployOrder(Player *owner, Territory *target, int armyUnits);
+
     /**
      * \brief   Constructs a DeployOrder object using values from another DeployOrder object
      * \param   order Other DeployOrder object to copy member variables from
      */
     DeployOrder(DeployOrder &order);
+
+    /**
+     * \brief   Deconstructs a DeployOrder object
+     */
+    ~DeployOrder() override;
 
     /**
      * \brief   Verifies if the order is valid
@@ -182,12 +231,18 @@ public:
      * \param   armyUnits Number of army units to be moved
      * \param   source  Territory from which troops are to be moved
      */
-    AdvanceOrder(OrdersList *ordersList, Territory *target, int armyUnits, Territory *source);
+    AdvanceOrder(Player *owner, Territory *target, int armyUnits, Territory *source);
+
     /**
      * \brief   Constructs an AdvanceOrder object using values from another AdvanceOrder object
      * \param   order Other AdvanceOrder object to copy member variables from
      */
     AdvanceOrder(AdvanceOrder &order);
+
+    /**
+     * \brief   Deconstructs an AdvanceOrder object
+     */
+    ~AdvanceOrder() override;
 
     /**
      * \brief   Verifies if the order is valid
@@ -230,12 +285,17 @@ public:
      * \param   type Type of the Order object created
      * \param   target Territory to be bombed
      */
-    BombOrder(OrdersList *ordersList, Territory *target);
+    BombOrder(Player *owner, Territory *target);
     /**
      * \brief   Constructs a BombOrder object using values from another BombOrder object
      * \param   order Other BombOrder object to copy member variables from
      */
     BombOrder(BombOrder &order);
+
+    /**
+     * \brief   Deconstructs a BombOrder object.
+     */
+    ~BombOrder() override;
 
     /**
      * \brief   Verifies if the order is valid
@@ -272,12 +332,17 @@ public:
      * \param   type Type of the Order object created
      * \param   target Territory to be blockaded
      */
-    BlockadeOrder(OrdersList *ordersList, Territory *target);
+    BlockadeOrder(Player *owner, Territory *target);
     /**
      * \brief   Constructs a BlockadeOrder object using values from another BlockadeOrder object
      * \param   order Other BlockadeOrder object to copy member variables from
      */
     BlockadeOrder(BlockadeOrder &order);
+
+    /**
+     * \brief   Deconstructs a BlockadeOrder object.
+     */
+    ~BlockadeOrder() override;
 
     /**
      * \brief   Verifies if the order is valid
@@ -316,12 +381,17 @@ public:
      * \param   armyUnits Number of army units to be moved
      * \param   source  Territory from which troops are to be moved
      */
-    AirliftOrder(OrdersList *ordersList, Territory *target, int armyUnits, Territory *source);
+    AirliftOrder(Player *owner, Territory *target, int armyUnits, Territory *source);
     /**
      * \brief   Constructs an AirliftOrder object using values from another AirliftOrder object
      * \param   order Other AirliftOrder object to copy member variables from
      */
     AirliftOrder(AirliftOrder &order);
+
+    /**
+     * \brief   Deconstructs an AirliftOrder object.
+     */
+    ~AirliftOrder() override;
 
     /**
      * \brief   Verifies if the order is valid
@@ -364,12 +434,17 @@ public:
      * \param   type Type of the Order object created
      * \param   player Player with whom negotiation happens
      */
-    NegotiateOrder(OrdersList *ordersList, Player *player);
+    NegotiateOrder(Player *owner, Player *player);
     /**
      * \brief   Constructs a NegotiateOrder object using values from another NegotiateOrder object
      * \param   order Other NegotiateOrder object to copy member variables from
      */
     NegotiateOrder(NegotiateOrder &order);
+
+    /**
+     * \brief   Deconstructs a NegotiateOrder object.
+     */
+    ~NegotiateOrder() override;
 
     /**
      * \brief   Verifies if the order is valid

--- a/src/Orders.cpp
+++ b/src/Orders.cpp
@@ -19,8 +19,22 @@ OrdersList::OrdersList(OrdersList &ordersList)
     owner = ordersList.owner;
 }
 
+Order *OrdersList::operator[](size_t index) {
+    if (index < orders.size()) {
+        auto iterator = orders.begin();
+        std::advance(iterator, index);
+        return *iterator;
+    }
+
+    return nullptr;
+}
+
 OrdersList &OrdersList::operator=(const OrdersList &ordersList)
 {
+    if (this == &ordersList) {
+
+    }
+
     orders = ordersList.orders;
     owner = ordersList.owner;
     return *this;
@@ -36,6 +50,33 @@ ostream &operator<<(ostream &outs, const OrdersList &ordersList)
     }
     outs << "}";
     return outs;
+}
+
+bool OrdersList::addOrder(Order *order) {
+    if (order != nullptr) {
+        orders.push_back(order);
+        return true;
+    }
+
+    return false;
+}
+
+const Player* OrdersList::getOwner() const {
+    return this->owner;
+}
+
+Order *OrdersList::getNextOrder() {
+    auto* nextOrder = orders.front();
+    orders.pop_front();
+    return nextOrder;
+}
+
+void OrdersList::apply(void (*func)(Order*)) {
+    for (auto* order : orders) {
+        if (order != nullptr) {
+            func(order);
+        }
+    }
 }
 
 void OrdersList::remove(Order *order)
@@ -77,25 +118,29 @@ bool OrdersList::move(Order *order, int index)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  ORDER
-Order::Order(OrdersList *ordersList, string type, Territory *target)
-{
-    Order::ordersList = ordersList;
-    Order::type = type;
-    Order::target = target;
+Order::Order(Player *owner, const string& type, Territory *target) {
+    this->owner = owner;
+    this->type = type;
+    this->target = target;
 }
 
 Order::Order(Order &order)
 {
-    ordersList = order.ordersList;
+    owner = order.owner;
     type = order.type;
     target = order.target;
 }
 
+Order::~Order() = default;
+
 Order &Order::operator=(const Order &order)
 {
-    ordersList = order.ordersList;
-    type = order.type;
-    target = order.target;
+    if (this != &order) {
+        owner = order.owner;
+        type = order.type;
+        target = order.target;
+    }
+
     return *this;
 }
 
@@ -106,8 +151,8 @@ ostream &operator<<(ostream &outs, const Order &order)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  DEPLOY ORDER
-DeployOrder::DeployOrder(OrdersList *ordersList, Territory *target, int armyUnits)
-    : Order(ordersList, "deploy", target)
+DeployOrder::DeployOrder(Player *owner, Territory *target, int armyUnits)
+    : Order(owner, "deploy", target)
 {
     DeployOrder::armyUnits = armyUnits;
 }
@@ -118,10 +163,15 @@ DeployOrder::DeployOrder(DeployOrder &order)
     DeployOrder::armyUnits = order.armyUnits;
 }
 
+DeployOrder::~DeployOrder() = default;
+
 DeployOrder &DeployOrder::operator=(const DeployOrder &order)
 {
-    Order::operator=(order);
-    armyUnits = order.armyUnits;
+    if (this != &order) {
+        Order::operator=(order);
+        armyUnits = order.armyUnits;
+    }
+
     return *this;
 }
 
@@ -133,8 +183,8 @@ ostream &operator<<(ostream &outs, const DeployOrder &order)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  ADVANCE ORDER
-AdvanceOrder::AdvanceOrder(OrdersList *ordersList, Territory *target, int armyUnits, Territory *source)
-    : Order(ordersList, "advance", target)
+AdvanceOrder::AdvanceOrder(Player *owner, Territory *target, int armyUnits, Territory *source)
+    : Order(owner, "advance", target)
 {
     AdvanceOrder::armyUnits = armyUnits;
     AdvanceOrder::source = source;
@@ -147,11 +197,16 @@ AdvanceOrder::AdvanceOrder(AdvanceOrder &order)
     AdvanceOrder::source = order.source;
 }
 
+AdvanceOrder::~AdvanceOrder() = default;
+
 AdvanceOrder &AdvanceOrder::operator=(const AdvanceOrder &order)
 {
-    Order::operator=(order);
-    armyUnits = order.armyUnits;
-    source = order.source;
+    if (this != &order) {
+        Order::operator=(order);
+        armyUnits = order.armyUnits;
+        source = order.source;
+    }
+
     return *this;
 }
 
@@ -163,19 +218,26 @@ ostream &operator<<(ostream &outs, const AdvanceOrder &order)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  BOMB ORDER
-BombOrder::BombOrder(OrdersList *ordersList, Territory *target)
-    : Order(ordersList, "bomb", target)
+BombOrder::BombOrder(Player *owner, Territory *target)
+    : Order(owner, "bomb", target)
 {
+    //  Empty
 }
 
 BombOrder::BombOrder(BombOrder &order)
     : Order(order)
 {
+    //  Empty
 }
+
+BombOrder::~BombOrder() = default;
 
 BombOrder &BombOrder::operator=(const BombOrder &order)
 {
-    Order::operator=(order);
+    if (this != &order) {
+        Order::operator=(order);
+    }
+
     return *this;
 }
 
@@ -186,19 +248,26 @@ ostream &operator<<(ostream &outs, const BombOrder &order)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  BLOCKADE ORDER
-BlockadeOrder::BlockadeOrder(OrdersList *ordersList, Territory *target)
-    : Order(ordersList, "blockade", target)
+BlockadeOrder::BlockadeOrder(Player *owner, Territory *target)
+    : Order(owner, "blockade", target)
 {
+    //  Empty
 }
 
 BlockadeOrder::BlockadeOrder(BlockadeOrder &order)
     : Order(order)
 {
+    //  Empty
 }
+
+BlockadeOrder::~BlockadeOrder() = default;
 
 BlockadeOrder &BlockadeOrder::operator=(const BlockadeOrder &order)
 {
-    Order::operator=(order);
+    if (this != &order) {
+        Order::operator=(order);
+    }
+
     return *this;
 }
 
@@ -209,8 +278,8 @@ ostream &operator<<(ostream &outs, const BlockadeOrder &order)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  AIRLIFT ORDER
-AirliftOrder::AirliftOrder(OrdersList *ordersList, Territory *target, int armyUnits, Territory *source)
-    : Order(ordersList, "airlift", target)
+AirliftOrder::AirliftOrder(Player *owner, Territory *target, int armyUnits, Territory *source)
+    : Order(owner, "airlift", target)
 {
     AirliftOrder::armyUnits = armyUnits;
     AirliftOrder::source = source;
@@ -223,11 +292,16 @@ AirliftOrder::AirliftOrder(AirliftOrder &order)
     AirliftOrder::source = order.source;
 }
 
+AirliftOrder::~AirliftOrder() = default;
+
 AirliftOrder &AirliftOrder::operator=(const AirliftOrder &order)
 {
-    Order::operator=(order);
-    armyUnits = order.armyUnits;
-    source = order.source;
+    if (this != &order) {
+        Order::operator=(order);
+        armyUnits = order.armyUnits;
+        source = order.source;
+    }
+
     return *this;
 }
 
@@ -239,8 +313,8 @@ ostream &operator<<(ostream &outs, const AirliftOrder &order)
 
 //----------------------------------------------------------------------------------------------------------------------
 //  NEGOTIATE ORDER
-NegotiateOrder::NegotiateOrder(OrdersList *ordersList, Player *player)
-    : Order(ordersList, "negotiate", NULL)
+NegotiateOrder::NegotiateOrder(Player *owner, Player *player)
+    : Order(owner, "negotiate", nullptr)
 {
     NegotiateOrder::player = player;
 }
@@ -251,10 +325,15 @@ NegotiateOrder::NegotiateOrder(NegotiateOrder &order)
     player = order.player;
 }
 
+NegotiateOrder::~NegotiateOrder() = default;
+
 NegotiateOrder &NegotiateOrder::operator=(const NegotiateOrder &order)
 {
-    Order::operator=(order);
-    player = order.player;
+    if (this != &order) {
+        Order::operator=(order);
+        player = order.player;
+    }
+
     return *this;
 }
 
@@ -273,38 +352,38 @@ bool Order::validate()
 bool DeployOrder::validate()
 {
     // TO DO: add verification of number of army units specified validity (reinforcement pool)
-    return Order::validate() && armyUnits > 0 && ((find(begin(ordersList->owner->territory), end(ordersList->owner->territory), target)) != end(ordersList->owner->territory));
+    return Order::validate() && armyUnits > 0 && ((find(begin(owner->territory), end(owner->territory), target)) != end(owner->territory));
 }
 
 bool AdvanceOrder::validate()
 {
-    return Order::validate() && source && armyUnits > 0 && armyUnits <= (*target).numberOfArmies && (find(begin((*source).adjacentTerritories), end((*source).adjacentTerritories), target) != end((*source).adjacentTerritories)) && ((find(begin(ordersList->owner->territory), end(ordersList->owner->territory), source)) != end(ordersList->owner->territory));
+    return Order::validate() && source && armyUnits > 0 && armyUnits <= (*target).numberOfArmies && (find(begin((*source).adjacentTerritories), end((*source).adjacentTerritories), target) != end((*source).adjacentTerritories)) && ((find(begin(owner->territory), end(owner->territory), source)) != end(owner->territory));
 }
 
 bool BombOrder::validate()
 {
-    return Order::validate() && (find_if(begin((*(*ordersList).owner).handCard), end((*(*ordersList).owner).handCard), [](const Card *card) -> bool
-                                         { return (*card).getCardType() == type::bomb; }) != end((*(*ordersList).owner).handCard)) &&
-           ((find(begin(ordersList->owner->territory), end(ordersList->owner->territory), target)) == end(ordersList->owner->territory));
+    return Order::validate() && (find_if(begin(owner->handCard), end(owner->handCard), [](const Card *card) -> bool
+                                         { return (*card).getCardType() == type::bomb; }) != end(owner->handCard)) &&
+           ((find(begin(owner->territory), end(owner->territory), target)) == end(owner->territory));
 }
 
 bool BlockadeOrder::validate()
 {
-    return Order::validate() && ((find(begin(ordersList->owner->territory), end(ordersList->owner->territory), target)) != end(ordersList->owner->territory)) && (find_if(begin((*(*ordersList).owner).handCard), end((*(*ordersList).owner).handCard), [](const Card *card) -> bool
-                                                                                                                                                                          { return (*card).getCardType() == type::blockade; }) != end((*(*ordersList).owner).handCard));
+    return Order::validate() && ((find(begin(owner->territory), end(owner->territory), target)) != end(owner->territory)) && (find_if(begin(owner->handCard), end(owner->handCard), [](const Card *card) -> bool
+                                                                                                                                                                          { return (*card).getCardType() == type::blockade; }) != end((owner->handCard)));
 }
 
 bool AirliftOrder::validate()
 {
-    return Order::validate() && source && armyUnits > 0 && armyUnits <= (*target).numberOfArmies && (find_if(begin((*(*ordersList).owner).handCard), end((*(*ordersList).owner).handCard), [](const Card *card) -> bool
-                                                                                                             { return (*card).getCardType() == type::airlift; }) != end((*(*ordersList).owner).handCard)) &&
-           ((find(begin(ordersList->owner->territory), end(ordersList->owner->territory), source)) != end(ordersList->owner->territory));
+    return Order::validate() && source && armyUnits > 0 && armyUnits <= (*target).numberOfArmies && (find_if(begin(owner->handCard), end(owner->handCard), [](const Card *card) -> bool
+                                                                                                             { return (*card).getCardType() == type::airlift; }) != end(owner->handCard)) &&
+           ((find(begin(owner->territory), end(owner->territory), source)) != end(owner->territory));
 }
 
 bool NegotiateOrder::validate()
 {
-    return (find(begin(allowedOrders), end(allowedOrders), type) != end(allowedOrders)) && player && (find_if(begin((*(*ordersList).owner).handCard), end((*(*ordersList).owner).handCard), [](const Card *card) -> bool
-                                                                                                              { return (*card).getCardType() == type::diplomacy; }) != end((*(*ordersList).owner).handCard));
+    return (find(begin(allowedOrders), end(allowedOrders), type) != end(allowedOrders)) && player && (find_if(begin(owner->handCard), end(owner->handCard), [](const Card *card) -> bool
+                                                                                                              { return (*card).getCardType() == type::diplomacy; }) != end(owner->handCard));
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -313,7 +392,7 @@ string Order::execute()
 {
     if (validate())
     {
-        cout << *this << " has been executed." << endl;
+        cout << *this << " has been executed.\n" << endl;
         return "Order has been executed.";
     }
     else

--- a/src/OrdersDriver.cpp
+++ b/src/OrdersDriver.cpp
@@ -26,49 +26,53 @@ void testOrdersLists()
     england->addAdjacentTerritory(france);
     england->addAdjacentTerritory(belgium);
 
-    player1->issueOrder("deploy", france, 2, NULL, NULL);
-    player1->issueOrder("advance", belgium, 4, france, NULL);
-    player1->issueOrder("bomb", england, 0, NULL, NULL);
-    player1->issueOrder("blockade", france, 0, NULL, NULL);
-    player1->issueOrder("airlift", england, 3, france, NULL);
-    player1->issueOrder("negotiate", NULL, 0, NULL, player2);
+    player1->issueOrder("deploy", france, 2, NULL, nullptr);
+    player1->issueOrder("advance", belgium, 4, france, nullptr);
+    player1->issueOrder("bomb", england, 0, NULL, nullptr);
+    player1->issueOrder("blockade", france, 0, NULL, nullptr);
+    player1->issueOrder("airlift", england, 3, france, nullptr);
+    player1->issueOrder("negotiate", NULL, 0, NULL, nullptr);
 
-    player2->issueOrder("deploy", france, 0, NULL, NULL);
-    player2->issueOrder("invalid type", NULL, 0, NULL, NULL);
-    player2->issueOrder("advance", belgium, 4, france, NULL);
-    player2->issueOrder("bomb", england, 0, NULL, NULL);
-    player2->issueOrder("blockade", france, 0, NULL, NULL);
-    player2->issueOrder("airlift", england, 3, france, NULL);
-    player2->issueOrder("negotiate", NULL, 0, NULL, player2);
+    player2->issueOrder("deploy", france, 0, NULL, nullptr);
+    player2->issueOrder("invalid type", NULL, 0, NULL, nullptr);
+    player2->issueOrder("advance", belgium, 4, france, nullptr);
+    player2->issueOrder("bomb", england, 0, NULL, nullptr);
+    player2->issueOrder("blockade", france, 0, NULL, nullptr);
+    player2->issueOrder("airlift", england, 3, france, nullptr);
+    player2->issueOrder("negotiate", NULL, 0, NULL, nullptr);
     cout << "ORDERS PART\n-------------------------------------------------------------\n";
 
+
+    OrdersList* player1_ordersList = player1->getOrdersList();
+    OrdersList* player2_ordersList = player2->getOrdersList();
+
+
     // Verify OrdersList.move()
-    cout << *(player2->getOrdersList()) << endl;
-    player2->getOrdersList()->move(*(player2->getOrdersList()->orders.begin()++), 4); // Moves first element to index 4 of the list
-    cout << *(player2->getOrdersList()) << endl;
-    player2->getOrdersList()->move(*(player2->getOrdersList()->orders.begin()++), -2); // Invalid case
-    player2->getOrdersList()->move(*(player1->getOrdersList()->orders.begin()++), 4);  // Invalid case
+    cout << *(player2_ordersList) << endl;
+    player2_ordersList->move((*player2_ordersList)[0], 4);   // Moves first element to index 4 of the list
+    cout << *(player2_ordersList) << endl;
+    player2_ordersList->move((*player2_ordersList)[0], -2);  //  Invalid case
+    player2_ordersList->move((*player1_ordersList)[0], 4);   //  Invalid case
     cout << "\n";
 
+
     // Verify OrdersList.remove()
-    player2->getOrdersList()->remove(*(player2->getOrdersList()->orders.begin()++)); // Removes first element of the list
+    player2_ordersList->remove((*player2_ordersList)[0]);   // Removes first element of the list
     cout << *(player2->getOrdersList()) << endl;
-    player2->getOrdersList()->remove(*(player1->getOrdersList()->orders.begin()++)); // Invalid case
+    player2_ordersList->remove((*player1_ordersList)[0]);   // Invalid case
     cout << "\n";
+
+
+    //  Anonymous function that takes an order and calls its 'execute()' function
+    auto executeOrderFunction = [] (Order* order) { order->execute(); return; };
 
     // Verify validate() and execute() of different Order types
     // Calling execute() suffices because each execute uses validate() in its implementation
     cout << "Valid Orders:\n";
-    list<Order *>::iterator itr;
-    for (itr = player1->getOrdersList()->orders.begin(); itr != player1->getOrdersList()->orders.end(); ++itr)
-    {
-        (*itr)->execute();
-    }
+    player1->getOrdersList()->apply(executeOrderFunction);
+
     cout << "\nInvalid Orders:\n";
-    for (itr = player2->getOrdersList()->orders.begin(); itr != player2->getOrdersList()->orders.end(); ++itr)
-    {
-        (*itr)->execute();
-    }
+    player2->getOrdersList()->apply(executeOrderFunction);
 
     cout << "\n-------------------------------------------------------------\n\n";
 }

--- a/src/OrdersDriver.cpp
+++ b/src/OrdersDriver.cpp
@@ -5,19 +5,19 @@
 
 void testOrdersLists()
 {
-    Player *player1 = new Player();
-    Player *player2 = new Player();
+    auto *player1 = new Player();
+    auto *player2 = new Player();
     player1->handCard.push_back(new Card(type::blockade));
     player1->handCard.push_back(new Card(type::bomb));
     player1->handCard.push_back(new Card(type::airlift));
     player1->handCard.push_back(new Card(type::diplomacy));
 
-    Continent *europe = new Continent("Europe", 100);
+    auto *europe = new Continent("Europe", 100);
 
-    Territory *france = new Territory("France", 5, 5, europe, player1, 5);
-    Territory *belgium = new Territory("Belgium", 6, 4, europe, player1, 5);
-    Territory *england = new Territory("England", 5, 3, europe, player2, 5);
-    Territory *greece = new Territory("Greece", 10, 12, europe, player1, 5);
+    auto *france = new Territory("France", 5, 5, europe, player1, 5);
+    auto *belgium = new Territory("Belgium", 6, 4, europe, player1, 5);
+    auto *england = new Territory("England", 5, 3, europe, player2, 5);
+    auto *greece = new Territory("Greece", 10, 12, europe, player1, 5);
 
     france->addAdjacentTerritory(belgium);
     france->addAdjacentTerritory(england);
@@ -26,20 +26,20 @@ void testOrdersLists()
     england->addAdjacentTerritory(france);
     england->addAdjacentTerritory(belgium);
 
-    player1->issueOrder("deploy", france, 2, NULL, nullptr);
+    player1->issueOrder("deploy", france, 2, nullptr, nullptr);
     player1->issueOrder("advance", belgium, 4, france, nullptr);
-    player1->issueOrder("bomb", england, 0, NULL, nullptr);
-    player1->issueOrder("blockade", france, 0, NULL, nullptr);
+    player1->issueOrder("bomb", england, 0, nullptr, nullptr);
+    player1->issueOrder("blockade", france, 0, nullptr, nullptr);
     player1->issueOrder("airlift", england, 3, france, nullptr);
-    player1->issueOrder("negotiate", NULL, 0, NULL, nullptr);
+    player1->issueOrder("negotiate", nullptr, 0, nullptr, nullptr);
 
-    player2->issueOrder("deploy", france, 0, NULL, nullptr);
-    player2->issueOrder("invalid type", NULL, 0, NULL, nullptr);
+    player2->issueOrder("deploy", france, 0, nullptr, nullptr);
+    player2->issueOrder("invalid type", nullptr, 0, nullptr, nullptr);
     player2->issueOrder("advance", belgium, 4, france, nullptr);
-    player2->issueOrder("bomb", england, 0, NULL, nullptr);
-    player2->issueOrder("blockade", france, 0, NULL, nullptr);
+    player2->issueOrder("bomb", england, 0, nullptr, nullptr);
+    player2->issueOrder("blockade", france, 0, nullptr, nullptr);
     player2->issueOrder("airlift", england, 3, france, nullptr);
-    player2->issueOrder("negotiate", NULL, 0, NULL, nullptr);
+    player2->issueOrder("negotiate", nullptr, 0, nullptr, nullptr);
     cout << "ORDERS PART\n-------------------------------------------------------------\n";
 
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -101,27 +101,27 @@ void Player::issueOrder(const string& type, Territory *target, int armyUnits, Te
 	Order *order;
 	if (type == "deploy")
 	{
-		order = new DeployOrder(ordersList, target, armyUnits);
+		order = new DeployOrder(this, target, armyUnits);
 	}
 	else if (type == "advance")
 	{
-		order = new AdvanceOrder(ordersList, target, armyUnits, source);
+		order = new AdvanceOrder(this, target, armyUnits, source);
 	}
 	else if (type == "bomb")
 	{
-		order = new BombOrder(ordersList, target);
+		order = new BombOrder(this, target);
 	}
 	else if (type == "blockade")
 	{
-		order = new BlockadeOrder(ordersList, target);
+		order = new BlockadeOrder(this, target);
 	}
 	else if (type == "airlift")
 	{
-		order = new AirliftOrder(ordersList, target, armyUnits, source);
+		order = new AirliftOrder(this, target, armyUnits, source);
 	}
 	else if (type == "negotiate")
 	{
-		order = new NegotiateOrder(ordersList, player);
+		order = new NegotiateOrder(this, player);
 	}
 	else
 	{
@@ -131,7 +131,7 @@ void Player::issueOrder(const string& type, Territory *target, int armyUnits, Te
         return;
 	}
 
-	(*ordersList).orders.push_back(order);
+	ordersList->addOrder(order);
 }
 
 OrdersList *Player::getOrdersList()


### PR DESCRIPTION
# Refactored code for the "Orders" section

The branch contains code for a revised version of the Orders section of the project. A few implementation and design issues were identified and resolved in this version.

### Issues Identified with the original
- Missing deconstructor declarations
- Incorrectly implemented copy assignment operator overrides
- Lack of encapsulation & breaking encapsulation
- A design issue with with `Order`


### Solutions to the above issues
- Missing deconstructor declarations

The `Orders` class and all its descendants ( `DeployOrder`, `AdvanceOrder`, `BombOrder`, `BlockadeOrder`, `AirliftOrder`, `NegotiateOrder`) have explicitly declared deconstructors.

- Incorrectly implemented copy assignment operator overrides

Copy assignment operators must check for self-assignment in order to avoid unexpected behavior and memory leaks. Self-assignment check added for each assignment check operator override as seen below:

```cpp
// Old
AirliftOrder &AirliftOrder::operator=(const AirliftOrder &order)
{
        Order::operator=(order);
        armyUnits = order.armyUnits;
        source = order.source;
        return *this;
}

// New
AirliftOrder &AirliftOrder::operator=(const AirliftOrder &order)
{
    if (this != &order) {
        Order::operator=(order);
        armyUnits = order.armyUnits;
        source = order.source;
    }

    return *this;
}
```

- Lack of encapsulation & breaking encapsulation

Member variables are now declared as private in order to maintain encapsulation. Multiple functions have been implemented to retain interaction with the internal list implementation. A notable function to note is the `void apply(void (*func)(Order*));` function. It takes a function pointer taking a `Order` object as an argument, then the function applies that function to all elements in the list. The purpose of this is to avoid external iteration using iterators, which cleans up code as seen below:

```cpp
// Old driver code
// Breaks encapsulation & complex/long declaration
for (itr = player1->getOrdersList()->orders.begin(); itr != player1->getOrdersList()->orders.end(); ++itr)
{
    (*itr)->execute();
}

for (itr = player2->getOrdersList()->orders.begin(); itr != player2->getOrdersList()->orders.end(); ++itr)
{
    (*itr)->execute();
}


// New driver code (performs the exact same function)
auto executeOrderFunction = [] (Order* order) { order->execute(); return; };
player1->getOrdersList()->apply(executeOrderFunction);
player2->getOrdersList()->apply(executeOrderFunction);
```

- A design issue with with `Order`

Originally, the class had an `OrderList` as a member variable. From code examination, the only use of this member variable was to refer to the player owning the OrderList - hence owning the Order. To simplify code, the class `Order` refers directly to the player owning it

```cpp
class Order
{
public:
    ...

protected:
    //  Pointer to the player that owns the object
    Player *owner;

    //  Was:
    //  OrdersList *ordersList;
    ...
};
```

### Reviewers
@dzm-fiodarau 